### PR TITLE
Update reference link to react new doc site

### DIFF
--- a/chart.drawio
+++ b/chart.drawio
@@ -1,4 +1,4 @@
-<mxfile host="app.diagrams.net" modified="2022-02-25T15:07:55.924Z" agent="5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/98.0.4758.109 Safari/537.36" etag="-cfSzGftLrrG70KvJqDV" version="16.6.4" type="github">
+<mxfile host="app.diagrams.net" modified="2023-08-24T17:08:47.341Z" agent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/116.0.0.0 Safari/537.36" etag="QuD-GU2rFCr_eXjD1PMR" version="21.6.9" type="device">
   <diagram id="4Y_KsI118iPX1C1HI_qV" name="Page-1">
     <mxGraphModel dx="1687" dy="897" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1100" pageHeight="850" math="0" shadow="0">
       <root>
@@ -52,7 +52,7 @@
         <mxCell id="peq8d5gX8DXLt__JmTx_-18" value="" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#d5e8d4;strokeColor=#82b366;gradientColor=#C8E8C5;" parent="1" vertex="1">
           <mxGeometry x="242" y="553" width="630" height="50" as="geometry" />
         </mxCell>
-        <UserObject label="&lt;h3 id=&quot;static-getderivedstatefromprops&quot;&gt;&lt;code&gt;&lt;font style=&quot;font-size: 14px&quot;&gt;&lt;a href=&quot;https://reactjs.org/docs/hooks-reference.html#usememo&quot;&gt;useMemo()&lt;/a&gt;&lt;/font&gt;&lt;/code&gt;&lt;/h3&gt;" tooltip="https://reactjs.org/docs/hooks-reference.html#usememo" id="peq8d5gX8DXLt__JmTx_-26">
+        <UserObject label="&lt;h3 id=&quot;static-getderivedstatefromprops&quot;&gt;&lt;code&gt;&lt;font style=&quot;font-size: 14px&quot;&gt;&lt;a href=&quot;https://react.dev/reference/react/useMemo&quot;&gt;useMemo()&lt;/a&gt;&lt;/font&gt;&lt;/code&gt;&lt;/h3&gt;" tooltip="https://react.dev/reference/react/usememo" id="peq8d5gX8DXLt__JmTx_-26">
           <mxCell style="rounded=1;whiteSpace=wrap;html=1;fillColor=#dae8fc;strokeColor=#6c8ebf;dashed=1;gradientColor=#E8F1FF;" parent="1" vertex="1">
             <mxGeometry x="292" y="236" width="90" height="30" as="geometry" />
           </mxCell>
@@ -69,7 +69,7 @@
             </Array>
           </mxGeometry>
         </mxCell>
-        <UserObject label="&lt;h3 id=&quot;static-getderivedstatefromprops&quot;&gt;&lt;code&gt;&lt;font style=&quot;font-size: 14px&quot;&gt;&lt;a href=&quot;https://reactjs.org/docs/hooks-reference.html#usecallback&quot;&gt;useCallback()&lt;/a&gt;&lt;/font&gt;&lt;/code&gt;&lt;/h3&gt;" tooltip="https://reactjs.org/docs/hooks-reference.html#usecallback" id="peq8d5gX8DXLt__JmTx_-32">
+        <UserObject label="&lt;h3 id=&quot;static-getderivedstatefromprops&quot;&gt;&lt;code&gt;&lt;font style=&quot;font-size: 14px&quot;&gt;&lt;a href=&quot;https://react.dev/reference/react/useCallback&quot;&gt;useCallback()&lt;/a&gt;&lt;/font&gt;&lt;/code&gt;&lt;/h3&gt;" tooltip="https://react.dev/reference/react/usecallback" id="peq8d5gX8DXLt__JmTx_-32">
           <mxCell style="rounded=1;whiteSpace=wrap;html=1;fillColor=#dae8fc;strokeColor=#6c8ebf;dashed=1;gradientColor=#E8F1FF;" parent="1" vertex="1">
             <mxGeometry x="707.92" y="266" width="124" height="30" as="geometry" />
           </mxCell>
@@ -86,12 +86,12 @@
             <mxPoint x="341" y="321" as="targetPoint" />
           </mxGeometry>
         </mxCell>
-        <UserObject label="&lt;h3 id=&quot;static-getderivedstatefromprops&quot;&gt;&lt;code style=&quot;font-size: 14px&quot;&gt;&lt;font style=&quot;font-size: 14px&quot;&gt;&lt;a href=&quot;https://reactjs.org/docs/hooks-reference.html#useeffect&quot;&gt;useEffect()&lt;/a&gt;&amp;nbsp;&lt;/font&gt;&lt;/code&gt;&lt;/h3&gt;" tooltip="https://reactjs.org/docs/hooks-reference.html#useeffect" id="peq8d5gX8DXLt__JmTx_-42">
+        <UserObject label="&lt;h3 id=&quot;static-getderivedstatefromprops&quot;&gt;&lt;code style=&quot;font-size: 14px&quot;&gt;&lt;font style=&quot;font-size: 14px&quot;&gt;&lt;a href=&quot;https://react.dev/reference/react/useEffect&quot;&gt;useEffect()&lt;/a&gt;&amp;nbsp;&lt;/font&gt;&lt;/code&gt;&lt;/h3&gt;" tooltip="https://react.dev/reference/react/useeffect" id="peq8d5gX8DXLt__JmTx_-42">
           <mxCell style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;" parent="1" vertex="1">
             <mxGeometry x="299" y="567" width="40" height="20" as="geometry" />
           </mxCell>
         </UserObject>
-        <UserObject label="&lt;h3 id=&quot;static-getderivedstatefromprops&quot;&gt;&lt;code style=&quot;font-size: 14px&quot;&gt;&lt;a href=&quot;https://reactjs.org/docs/hooks-reference.html#useeffect&quot;&gt;useLayoutEffect()&lt;/a&gt;&amp;nbsp;&lt;/code&gt;&lt;/h3&gt;&lt;h3 id=&quot;static-getderivedstatefromprops&quot;&gt;&lt;code&gt;&lt;font size=&quot;1&quot;&gt;&lt;a href=&quot;https://reactjs.org/docs/hooks-reference.html#uselayouteffect&quot;&gt;&lt;/a&gt;&lt;/font&gt;&lt;/code&gt;&lt;/h3&gt;" tooltip="https://reactjs.org/docs/hooks-reference.html#uselayouteffect" link="https://reactjs.org/docs/hooks-reference.html#uselayouteffect" linkTarget="_blank" id="peq8d5gX8DXLt__JmTx_-43">
+        <UserObject label="&lt;h3 id=&quot;static-getderivedstatefromprops&quot;&gt;&lt;code style=&quot;font-size: 14px&quot;&gt;useLayoutEffect()&amp;nbsp;&lt;/code&gt;&lt;/h3&gt;&lt;h3 id=&quot;static-getderivedstatefromprops&quot;&gt;&lt;code&gt;&lt;font size=&quot;1&quot;&gt;&lt;a href=&quot;https://react.dev/reference/react/useLayoutEffect&quot;&gt;&lt;/a&gt;&lt;/font&gt;&lt;/code&gt;&lt;/h3&gt;" tooltip="https://react.dev/reference/react/uselayouteffect" linkTarget="_blank" id="peq8d5gX8DXLt__JmTx_-43">
           <mxCell style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;" parent="1" vertex="1">
             <mxGeometry x="435" y="567" width="40" height="20" as="geometry" />
           </mxCell>
@@ -110,17 +110,17 @@
             <mxGeometry x="20" width="332" height="30" as="geometry" />
           </mxCell>
         </UserObject>
-        <UserObject label="&lt;h3 id=&quot;static-getderivedstatefromprops&quot;&gt;&lt;code&gt;&lt;font color=&quot;#3399ff&quot; style=&quot;font-size: 14px&quot;&gt;&lt;a href=&quot;https://reactjs.org/docs/hooks-reference.html#usestate&quot;&gt;useState()&lt;/a&gt;&lt;/font&gt;&lt;/code&gt;&lt;/h3&gt;" tooltip="https://reactjs.org/docs/hooks-reference.html#usestate" id="peq8d5gX8DXLt__JmTx_-39">
+        <UserObject label="&lt;h3 id=&quot;static-getderivedstatefromprops&quot;&gt;&lt;code&gt;&lt;font style=&quot;font-size: 14px&quot; color=&quot;#3399ff&quot;&gt;&lt;a href=&quot;https://react.dev/reference/react/useState&quot;&gt;useState()&lt;/a&gt;&lt;/font&gt;&lt;/code&gt;&lt;/h3&gt;" tooltip="https://react.dev/reference/react/usestate" id="peq8d5gX8DXLt__JmTx_-39">
           <mxCell style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;" parent="Qn97D7aN3kyVjcPedb_y-5" vertex="1">
             <mxGeometry x="58" y="5" width="40" height="20" as="geometry" />
           </mxCell>
         </UserObject>
-        <UserObject label="&lt;h3 id=&quot;static-getderivedstatefromprops&quot;&gt;&lt;code&gt;&lt;font color=&quot;#3399ff&quot; style=&quot;font-size: 14px&quot;&gt;&lt;a href=&quot;https://reactjs.org/docs/hooks-reference.html#usereducer&quot;&gt;useReducer()&lt;/a&gt;&lt;/font&gt;&lt;/code&gt;&lt;/h3&gt;" tooltip="https://reactjs.org/docs/hooks-reference.html#usereducer" id="peq8d5gX8DXLt__JmTx_-40">
+        <UserObject label="&lt;h3 id=&quot;static-getderivedstatefromprops&quot;&gt;&lt;code&gt;&lt;font style=&quot;font-size: 14px&quot; color=&quot;#3399ff&quot;&gt;&lt;a href=&quot;https://react.dev/reference/react/useReducer&quot;&gt;useReducer()&lt;/a&gt;&lt;/font&gt;&lt;/code&gt;&lt;/h3&gt;" tooltip="https://react.dev/reference/react/usereducer" id="peq8d5gX8DXLt__JmTx_-40">
           <mxCell style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;" parent="Qn97D7aN3kyVjcPedb_y-5" vertex="1">
             <mxGeometry x="162" y="5" width="40" height="20" as="geometry" />
           </mxCell>
         </UserObject>
-        <UserObject label="&lt;h3 id=&quot;static-getderivedstatefromprops&quot;&gt;&lt;code&gt;&lt;font color=&quot;#3399ff&quot; style=&quot;font-size: 14px&quot;&gt;&lt;a href=&quot;https://reactjs.org/docs/hooks-reference.html#usecontext&quot; style=&quot;line-height: 1&quot;&gt;useContext()&lt;/a&gt;&lt;/font&gt;&lt;/code&gt;&lt;/h3&gt;" tooltip="https://reactjs.org/docs/hooks-reference.html#usecontext" id="peq8d5gX8DXLt__JmTx_-41">
+        <UserObject label="&lt;h3 id=&quot;static-getderivedstatefromprops&quot;&gt;&lt;code&gt;&lt;font style=&quot;font-size: 14px&quot; color=&quot;#3399ff&quot;&gt;&lt;a style=&quot;line-height: 1&quot; href=&quot;https://react.dev/reference/react/useContext&quot;&gt;useContext()&lt;/a&gt;&lt;/font&gt;&lt;/code&gt;&lt;/h3&gt;" tooltip="https://react.dev/reference/react/usecontext" id="peq8d5gX8DXLt__JmTx_-41">
           <mxCell style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;" parent="Qn97D7aN3kyVjcPedb_y-5" vertex="1">
             <mxGeometry x="275.5" y="5" width="40" height="20" as="geometry" />
           </mxCell>


### PR DESCRIPTION
Looks like `reactjs.org/docs` is legacy and new site is `react.dev/reference`